### PR TITLE
Update go version in Dockerfile local

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM golang:1.24
+FROM golang:1.25
 
 ENV GOCACHE=/go/.go/cache GOPATH=/go/.go/path TZ=Europe/London
 


### PR DESCRIPTION
### What

The version of go in the Dockerfile.local was older than the one in go.mod. This caused it to error in the legacy core publishing stack (in dp-compose). So I've updated the version to be the same.

### How to review

Sense check.

### Who can review

Anyone in Open Sauce.